### PR TITLE
Add python3 compatibility

### DIFF
--- a/octoprint_estop/__init__.py
+++ b/octoprint_estop/__init__.py
@@ -45,6 +45,7 @@ class EstopPlugin(octoprint.plugin.StartupPlugin,
 		)
 
 __plugin_name__ = "Emergency Stop Button"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__


### PR DESCRIPTION
Tested on my python3 install of octoprint and it seems to work fine without any other changes.